### PR TITLE
v0.1.1.0 release

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -51,3 +51,13 @@ you must be able to justify that.
 
 - [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
 - [ ] My code complies with the [style guide](../tree/main/docs/code-style.md).
+
+## ✓ Release Checklist
+
+- [ ] I updated the version number in `package.yaml`.
+- [ ] If any definitions (functions, type classes, instances, etc) were added,
+      I added [`@since` haddock annotations](https://haskell-haddock.readthedocs.io/en/latest/markup.html#since).
+- [ ] (After merging) I created a new entry in the [releases](https://github.com/serokell/tztime/releases) page,
+      with a summary of all user-facing changes.
+    *  I made sure a tag was created.
+- [ ] (After merging) I uploaded the package to [hackage](https://hackage.haskell.org/package/tztime).

--- a/package.yaml
+++ b/package.yaml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 name:                tztime
-version:             0.1.0.0
+version:             0.1.1.0
 github:              serokell/tztime
 license:             MPL-2.0
 license-file:        LICENSE

--- a/src/Data/Time/TZTime/Internal.hs
+++ b/src/Data/Time/TZTime/Internal.hs
@@ -112,8 +112,11 @@ tzTimeTZInfo = tztTZInfo
 tzTimeOffset :: TZTime -> TimeZone
 tzTimeOffset = tztOffset
 
+-- | @since 0.1.1.0
 instance HasField "tzTimeLocalTime" TZTime LocalTime where getField = tzTimeLocalTime
+-- | @since 0.1.1.0
 instance HasField "tzTimeTZInfo" TZTime TZInfo where getField = tzTimeTZInfo
+-- | @since 0.1.1.0
 instance HasField "tzTimeOffset" TZTime TimeZone where getField = tzTimeOffset
 
 ----------------------------------------------------------------------------

--- a/tztime.cabal
+++ b/tztime.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           tztime
-version:        0.1.0.0
+version:        0.1.1.0
 synopsis:       Safe timezone-aware handling of time.
 description:    This package introduces:
                 .


### PR DESCRIPTION
## Description

v0.1.1.0 release with improved support for `OverloadedRecordDot`



## ✓ Release Checklist

- [x] I updated the version number in `package.yaml`.
- [x] If any definitions (functions, type classes, instances, etc) were added,
      I added [`@since` haddock annotations](https://haskell-haddock.readthedocs.io/en/latest/markup.html#since).
- [x] (After merging) I created a new entry in the [releases](https://github.com/serokell/tztime/releases) page,
      with a summary of all user-facing changes.
    *  I made sure a tag was created.
- [x] (After merging) I uploaded the package to [hackage](https://hackage.haskell.org/package/tztime).

